### PR TITLE
feat(serve): Add Qwen3 thinking mode and first chunk removal

### DIFF
--- a/lmdeploy/patch/monkey_patch.py
+++ b/lmdeploy/patch/monkey_patch.py
@@ -1,5 +1,9 @@
 import logging
+import re
+import orjson
 
+from starlette.responses import StreamingResponse
+from starlette.types import Send
 from argparse import _SubParsersAction, ArgumentParser
 from functools import cache
 from lmdeploy.cli.serve import SubCliServe
@@ -7,6 +11,9 @@ from lmdeploy.serve.openai import api_server as openai_api_serve
 from lmdeploy.serve.openai.protocol import StreamOptions
 
 logger = logging.getLogger(__name__)
+
+# Compile the regex for checking /think or /nothink at the end of the string
+THINKING_TAG_REGEX = re.compile(r"/(think|nothink)\s*$")
 
 class ApiServeCliContext:
     args = None
@@ -23,6 +30,24 @@ def get_stream_include_usage_status():
     except:
         return False
     
+@cache
+def get_args_qwen3_enable_thinking():
+    """Get the status of Qwen3 enable thinking mode."""
+    try:
+        return ApiServeCliContext.args.qwen3_enable_thinking
+    except:
+        return False
+
+@cache
+def get_remove_first_think_chunk_status():
+    """Get the status of whether to remove the first chunk if it contains '<think>'."""
+    try:
+        status = getattr(ApiServeCliContext.args, "remove_first_think_chunk")
+        print(f"remove_first_think_chunk: {status}")
+        return status
+    except:
+        return False
+
 _origin_parse_args = ArgumentParser.parse_args
 def _patch_parse_args(self, args=None, namespace=None):
     """Patch the parse_args method to set the API serve CLI context if the command is 'serve'."""
@@ -42,28 +67,143 @@ def get_api_serve_cli_context():
     
     
 _origin_api_serve_check_request = openai_api_serve.check_request
+
+
+def _handle_qwen3_thinking(request, qwen3_enable_thinking):
+    """Handle Qwen3 thinking logic based on model name and enable flag."""
+    try:
+        # If qwen3 thinking is not enabled, return
+        if not qwen3_enable_thinking:
+            return
+
+        # Ensure messages exist and is a list
+        if not request.messages or not isinstance(request.messages, list):
+            return
+
+        last_message = request.messages[-1]
+
+        # Ensure the last message is a dictionary and has content
+        if not isinstance(last_message, dict) or "content" not in last_message:
+            return
+
+        content = last_message["content"]
+        model_name = request.model
+        _enable_think = True if model_name.endswith("-think") else False
+        if _enable_think:
+            #   # Patch SubCliServe
+            request.model = model_name.rstrip("-think")
+        # Check if content already ends with /think or /nothink followed by optional whitespace
+        if THINKING_TAG_REGEX.search(content):
+            return
+
+        # Determine the tag to add based on model name
+        if _enable_think:
+            last_message["content"] += " /think"
+        else:
+            last_message["content"] += " /nothink"
+
+    except Exception as e:
+        logger.error(f"Error processing qwen3_enable_thinking: {e}")
+
+_origin_stream_response = StreamingResponse.stream_response
+
+# BUG: This is a temporary patch to handle the first chunk of the stream
+# which might contain a "<think>" tag that needs to be ignored.
+def _check_and_handle_first_chunk(chunk: bytes) -> bool:
+    """
+    Checks if the current chunk contains the "<think>" tag and should be ignored.
+
+    Args:
+        chunk: The current chunk of data.
+
+    Returns:
+        A boolean indicating if the current chunk should be ignored.
+    """
+    ignore_first_chunk = False
+    try:
+        # Attempt to parse the chunk as JSON
+        parser_chunk = chunk.lstrip(b'data:')
+        chunk_data = orjson.loads(parser_chunk)
+        choices = chunk_data.get("choices", [])
+        if choices:
+            delta = choices[0].get('delta', {})
+            content = delta.get('content')
+            if content == "<think>":
+                # logger.debug("Ignoring first chunk containing '<think>'")
+                ignore_first_chunk = True
+    except orjson.JSONDecodeError:
+        # Handle cases where the first chunk is not valid JSON
+        logger.warning("Failed to decode first chunk as JSON. Proceeding without ignoring.")
+    except Exception as e:
+        # Catch any other unexpected errors during processing
+        logger.error(f"An unexpected error occurred while processing the first chunk: {e}")
+
+    return ignore_first_chunk
+
+async def _patch_stream_response(self, send: Send) -> None:
+    await send(
+        {
+            "type": "http.response.start",
+            "status": self.status_code,
+            "headers": self.raw_headers,
+        }
+    )
+
+    _is_first_chunk = True
+    async for chunk in self.body_iterator:
+        if not isinstance(chunk, (bytes, memoryview)):
+            chunk = chunk.encode(self.charset)
+
+        ignore_first_chunk = False
+        if _is_first_chunk and get_remove_first_think_chunk_status():
+            ignore_first_chunk = _check_and_handle_first_chunk(chunk)
+        _is_first_chunk = False
+
+        if not ignore_first_chunk:
+            await send({"type": "http.response.body", "body": chunk, "more_body": True})
+
+    await send({"type": "http.response.body", "body": b"", "more_body": False})
+
 def _patch_api_serve_check_request(request):
     """Patch the check_request method to include stream usage data if enabled."""
+    logger.info("Entering _patch_api_serve_check_request")
     enable_stream_include_usage_status = get_stream_include_usage_status()
     if enable_stream_include_usage_status:
         stream_options = getattr(request, "stream_options", None)
         if not stream_options:
             stream_options = StreamOptions(include_usage=True)
             request.stream_options = stream_options
-            
+            logger.info("Enabled stream_options.include_usage")
+    qwen3_enable_thinking = get_args_qwen3_enable_thinking()
+    logger.info(f"qwen3_enable_thinking: {qwen3_enable_thinking}")
+    logger.info(f"Request before handling qwen3 thinking: {request.json()}")
+    _handle_qwen3_thinking(request, qwen3_enable_thinking)
+    logger.info(f"Request after handling qwen3 thinking: {request.json()}")
     r = _origin_api_serve_check_request(request)
+    logger.info("Exiting _patch_api_serve_check_request")
     return r
      
-    
 def _patch_api_server_add_parser(parser):
-    """Patch the API server parser to add the --enable-stream-include-usage argument."""
+    """Patch the API server parser to add necessary arguments."""
     parser.add_argument(
         "--enable-stream-include-usage",
         action="store_true",
         help="Enable the inclusion of stream usage data in the output, useful for monitoring performance.",
     )
+    parser.add_argument(
+        "--qwen3-enable-thinking",
+        action="store_true",
+        default=False,
+        help="Enable Qwen3 thinking mode. If not set, will check environment variable QWEN3_ENABLE_THINKING. Default: off. "
+             "If model name is Qwen3-1.7B, thinking is off by default. If model name is Qwen3-1.7B-think, thinking is on."
+    )
+    parser.add_argument(
+        "--remove-first-think-chunk",
+        action="store_true",
+        default=False,
+        help="Enable removal of the first chunk if it contains the '<think>' tag."
+    )
     return parser
-
 
 def _patch_sub_parser_add_parser(self, name, **kwargs):
     """Patch the subparser add_parser method to include the --enable-stream-include-usage argument for 'api_server'."""
@@ -75,7 +215,6 @@ def _patch_sub_parser_add_parser(self, name, **kwargs):
     _parser = _patch_api_server_add_parser(_parser)
 
     return _parser
-
 
 def patch_all():
     """Apply all monkey patches."""
@@ -90,3 +229,8 @@ def patch_all():
     
     # Patch ArgumentParser
     ArgumentParser.parse_args = _patch_parse_args
+
+    # Always apply the patch to remove the first chunk, the behavior is controlled by get_remove_first_think_chunk_status() at runtime
+    StreamingResponse._origin_stream_response = _origin_stream_response
+    StreamingResponse.stream_response = _patch_stream_response
+    logger.info("Patch for removing the first chunk applied.")


### PR DESCRIPTION
- Add `--qwen3-enable-thinking` and `--remove-first-think-chunk` arguments.
- Implement logic to handle Qwen3 thinking tags in messages.
- Patch `StreamingResponse` to optionally remove the first chunk containing `<think>`.

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
